### PR TITLE
Resolve externs from node_modules.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,19 @@
 module.exports = {
-    "extends": "opensphere",
-    "rules": {
-      "max-len": [
-        1,
-        120,
-        4,
-        {
-          "ignoreComments": true,
-          "ignoreUrls": true
-        }]
-    }
+  "extends": "google",
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
+  "rules": {
+    // don't dangle commas
+    "comma-dangle": ["error", "never"],
+    // pre-ES6 engines need to be able to use objects as maps
+    "guard-for-in": "off",
+    // increase max line length
+    "max-len": ["error", { "code": 120 }],
+    // This is silly. Negated conditions are highly useful and often much more concise than
+    // their complements.
+    "no-negated-condition": "off",
+    // allow use of var
+    "no-var": "off"
+  }
 };

--- a/genconf.js
+++ b/genconf.js
@@ -84,6 +84,31 @@ const appendSourcesJsdoc = function(config) {
 };
 
 /**
+ * Resolves absolute paths for externs.
+ *
+ * @param {Object} config The JSDoc configuration object
+ */
+const resolveExterns = function(config) {
+  if (config.externs) {
+    config.externs = config.externs.map(function(externPath) {
+      var match = externPath.match(/(.*?)\/(.*)/);
+      if (match.length === 3) {
+        try {
+          var moduleName = match[1];
+          var modulePath = path.dirname(require.resolve(path.join(moduleName, 'package.json')));
+          if (modulePath) {
+            return path.join(modulePath, match[2]);
+          }
+        } catch (e) {
+        }
+      }
+
+      return externPath;
+    });
+  }
+};
+
+/**
  * Merges the base JSDoc configuration with the project configuration.
  * @param {string} inputPath Path to the project configuration
  * @return {Object} The merged configuration
@@ -134,6 +159,7 @@ const processJsdocConf = function() {
 
         // read sources from the manifest and add them to the config
         appendSourcesDossier(config);
+        resolveExterns(config);
       }
 
       // write the config to the output path

--- a/os-docs.js
+++ b/os-docs.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const childProcess = require('child_process');
+const Promise = require('bluebird');
+const path = require('path');
+
+const dossierJarPath = path.join(path.dirname(require.resolve('js-dossier/package.json')), 'dossier.jar');
+
+let args;
+if (process.argv.length < 3) {
+  console.error('Please provide the js-dossier arguments');
+  process.exit(1);
+} else {
+  args = process.argv.slice(2);
+}
+
+const compile = function(args) {
+  return new Promise(function(resolve, reject) {
+    let javaArgs = ['-jar', dossierJarPath].concat(args);
+
+    const process = childProcess.spawn('java', javaArgs);
+    process.stdout.on('data', function(data) {
+      console.log(data.toString());
+    });
+
+    process.stderr.on('data', function(data) {
+      console.log(data.toString());
+    });
+
+    process.on('error', function(err) {
+      throw new Error('js-dossier failed: ' + (err.message || 'Unspecified error'));
+    });
+
+    process.on('exit', function(code) {
+      resolve();
+    });
+  });
+};
+
+compile(args);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Generates API documentation for Closure projects.",
   "bin": {
+    "os-docs": "./os-docs.js",
     "os-docs-gen-config": "./genconf.js"
   },
   "main": "genconf.js",
@@ -37,7 +38,7 @@
   },
   "config": {
     "commitizen": {
-      "path": "node_modules/cz-conventional-changelog"
+      "path": "cz-conventional-changelog"
     },
     "validate-commit-msg": {
       "helpMessage": "\nPlease fix your commit message (consider using 'npm i -g commitizen'). Well-formatted commit messages allow us to automate our changelog and npm releases.\n\nExamples:\n\"fix(copy-view): Fixed an error when resolving paths for view directories\"\n\"feat(gcc): Added support for defines\"\n\nIf you have installed commitizen, try running 'git cz'."


### PR DESCRIPTION
Using `require` to resolve `node_modules` paths allows using a yarn workspace with a shared `node_modules` directory. Also adds an `os-docs` process so projects switching to yarn don't have to use a direct path to the js-dossier JAR in their package.json.

These changes are compatible with an npm based workspace.