### PR TITLE
Suppress warning output unless --verbose flag provided.

### DIFF
--- a/os-docs.js
+++ b/os-docs.js
@@ -7,13 +7,24 @@ const Promise = require('bluebird');
 const path = require('path');
 
 const dossierJarPath = path.join(path.dirname(require.resolve('js-dossier/package.json')), 'dossier.jar');
+const warningRE = /WARNING/;
 
 let args;
+let verbose = false;
 if (process.argv.length < 3) {
   console.error('Please provide the js-dossier arguments');
   process.exit(1);
 } else {
   args = process.argv.slice(2);
+
+  // check if verbose warning output is enabled
+  let verboseIndex = args.indexOf('--verbose');
+  if (verboseIndex > -1) {
+    verbose = true;
+
+    // don't pass the flag to js-dossier
+    args.splice(verboseIndex, 1);
+  }
 }
 
 const compile = function(args) {
@@ -26,7 +37,11 @@ const compile = function(args) {
     });
 
     process.stderr.on('data', function(data) {
-      console.log(data.toString());
+      data = data.toString().trim();
+
+      if (data && (verbose || !warningRE.test(data))) {
+        console.log(data);
+      }
     });
 
     process.on('error', function(err) {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "main": "genconf.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint:changed": "if git diff --name-only HEAD | grep -q 'genconf.js'; then npm run lint; fi",
-    "lint": "eslint genconf.js",
+    "lint:changed": "if git diff --name-only HEAD | grep -q '\\.js$'; then npm run lint; fi",
+    "lint": "eslint *.js",
     "package:update": "if git diff --name-only ORIG_HEAD HEAD | grep --quiet package.json; then echo 'UPDATE: package.json changed, consider running yarn in your workspace root'; fi",
     "precommit": "npm run lint:changed",
     "commitmsg": "validate-commit-msg",


### PR DESCRIPTION
The thousands of warnings js-dossier spits out are not helpful. Errors should fail the build and be logged, warnings can be suppressed unless someone wants to work on fixing them and provides the `--verbose` flag.