### PR TITLE
feat(dossier): add direct dependency for js-dossier

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "build",
     "closure",
     "compiler",
-    "jsdoc",
     "api"
   ],
   "license": "Apache-2.0",
@@ -54,7 +53,7 @@
   "dependencies": {
     "deepmerge": "^1.1.1",
     "fs": "0.0.1-security",
-    "jsdoc": "^3.4.2",
+    "js-dossier": "^0.15.0",
     "opensphere-build-closure-helper": "^3.0.1",
     "path": "^0.12.7"
   },


### PR DESCRIPTION
This update also resolves API doc compile errors that were caused by Closure compiler/library version conflicts between `opensphere` and `js-dossier`.

BREAKING CHANGE: This project now directly depends on js-dossier to resolve
version issues related to hoisted dependencies. Other projects should remove
their dependency on js-dossier and use the inherited version instead.